### PR TITLE
fix(tox): use comma-separated values in passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ platform =
     macos: darwin
     linux: linux
     windows: win32
-passenv = CI GITHUB_ACTIONS DISPLAY XAUTHORITY
+passenv = CI,GITHUB_ACTIONS,DISPLAY,XAUTHORITY
 setenv =
     PYTHONPATH = {toxinidir}
 extras =


### PR DESCRIPTION
The `passenv` directive in tox.ini uses space-separated values, but tox requires comma-separated values for multiple environment variables.

This causes all CI jobs to fail with:
```
pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'CI GITHUB_ACTIONS DISPLAY XAUTHORITY'
```

Fix: replace spaces with commas in the passenv line.